### PR TITLE
Modifications in bash.sh and others file templates, etc/hosts,..…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,22 @@ Example of a 5-node cluster:
 3. Git clone this project, and change directory into this project directory.
 5. `vagrant up` to create the VM.
 6. `vagrant ssh node-1` to get into your Spark master node.
-7. `/home/vagrant/spark/sbin/start-all.sh` to start Spark master and all slave nodes.
+7. `/home/vagrant/spark/sbin/start-all.sh` to start Spark master and all slave nodes. This is deprecated. Need to do as follow:
+7a. Start hadoop (namenode at master and datanode at slaves): 
+	`/home/vagrant/hadoop/sbin/start-dfs.sh`
+7b. Start yarn (ResourceManager at master and NodeManager at slaves): 
+	`/home/vagrant/hadoop/sbin/start-yarn.sh`	
+	Check at each node to see if the processes are successfully turned on. 
+	`jps`
+7c. Start Spark:
+	`/home/vagrant/spark/sbin/start-master.sh` to start Master Node
+	`/home/vagrant/spark/sbin/start-slaves.sh` to start the Slave Nodes
 8. Point your browser at `http://192.168.100.101:8080/` to visualize the Spark UI.
 9. `vagrant halt` to turn off the cluster, `vagrant up` to turn it on again and `vagrant destroy` if you want to destroy and get rid it.
 
 ## Note
 To avoid downloading vagrant box many times, one can manually download the box at [precise64 box](https://files.hashicorp.com/precise64.box) and put it in `box/precise64.box`. Same for [spark](https://d3kbcqa49mib13.cloudfront.net/spark-2.2.0-bin-hadoop2.7.tgz) and `resources/spark-2.2.0-bin-hadoop2.7.tgz` (in which case you have to modify `scripts/bootstrap.sh` to copy spark from `/vagrant/resources` to VM instead of using `wget`).
+
+## Note 2: Some tricks to debug:
+1. `netstat -aln` : to see the connections in and out. 
+2. Once we stop Hadoop service, please run the file `clear_datanode.sh` on slaves and `clear_namenode.sh` on master to clean up the disk, and re-format the namenode, before starting Hadoop again.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,14 +7,14 @@ ipAdrPrefix = "192.168.100.10"
 memTot = 30000
 numNodes = 3
 memory = memTot/numNodes
-cpuCap = 100/numNodes
+cpuCap = 75/numNodes
 
 Vagrant.configure(2) do |config|
 	r = numNodes..1
 	(r.first).downto(r.last).each do |i|
 		config.vm.define "node-#{i}" do |node|
-			#node.vm.box = "hashicorp/precise64"
-			node.vm.box = "box/precise64.box"
+			node.vm.box = "hashicorp/precise64"
+			# node.vm.box = "box/precise64.box"
 			node.vm.provider "virtualbox" do |v|
 				v.name = "spark-node#{i}"
 				v.customize ["modifyvm", :id, "--cpuexecutioncap", cpuCap]

--- a/resources/hadoop/clear_datanode.sh
+++ b/resources/hadoop/clear_datanode.sh
@@ -1,0 +1,3 @@
+cd $HADOOP_HOME
+cd hdfs
+rm -r datanode/

--- a/resources/hadoop/clear_namenode.sh
+++ b/resources/hadoop/clear_namenode.sh
@@ -1,0 +1,5 @@
+rm -Rf /usr/local/hadoop/tmp
+cd $HADOOP_HOME/hdfs
+rm -r datanode/
+rm -r namenode/
+$HADOOP_HOME/bin/hdfs namenode -format

--- a/resources/hadoop/yarn-default.xml
+++ b/resources/hadoop/yarn-default.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!-- yarn-site.xml -->
+<configuration>
+ <property>
+  <name>yarn.scheduler.minimum-allocation-vcores</name>
+  <value>1</value>
+ </property>
+ <property>
+   <name>yarn.scheduler.minimum-allocation-mb</name>
+   <value>1024</value>
+ </property>
+ <property>
+  <name>yarn.scheduler.minimum-allocation-vcores</name>
+  <value>1</value>
+ </property>
+ <property>
+  <name>yarn.scheduler.maximum-allocation-mb</name>
+  <value>10000</value>
+ </property>
+</configuration>

--- a/resources/hadoop/yarn-site_old.xml
+++ b/resources/hadoop/yarn-site_old.xml
@@ -7,12 +7,20 @@
   <value>hadoop-master</value>
  </property>
  <property>
+  <name>yarn.resourcemanager.bind-host</name>
+  <value>0.0.0.0</value>
+ </property>
+ <property>
+  <name>yarn.nodemanager.bind-host</name>
+  <value>0.0.0.0</value> 
+ </property>
+ <property>
   <name>yarn.nodemanager.aux-services</name>
   <value>mapreduce_shuffle</value>
  </property>
  <property>
   <name>yarn.nodemanager.aux-services.mapreduce_shuffle.class</name>
- <value>org.apache.hadoop.mapred.ShuffleHandler</value>
+  <value>org.apache.hadoop.mapred.ShuffleHandler</value>
  </property>
  <property>
   <name>yarn.log-aggregation-enable</name>
@@ -30,32 +38,4 @@
   <name>yarn.nodemanager.remote-app-log-dir</name>
   <value>hdfs://hadoop-master:8020/var/log/hadoop-yarn/apps</value>
  </property>
-<property>
-    <name>yarn.resourcemanager.scheduler.address</name>
-    <value>hadoop-master:8030</value>
-  </property>
-  <property>
-    <name>yarn.resourcemanager.address</name>
-    <value>hadoop-master:8032</value>
-  </property>
-  <property>
-    <name>yarn.resourcemanager.webapp.address</name>
-    <value>hadoop-master:8088</value>
-  </property>
- <property>
-    <name>yarn.resourcemanager.resource-tracker.address</name>
-    <value>hadoop-master:8031</value>
-  </property>
-  <property>
-    <name>yarn.resourcemanager.admin.address</name>
-    <value>hadoop-master:8033</value>
-  </property>
- <property>
-    <name>yarn.scheduler.minimum-allocation-mb</name>
-    <value>1024</value>
-  </property>
- <property>
-    <name>yarn.scheduler.minimum-allocation-vcores</name>
-    <value>1</value>
-  </property>
 </configuration>


### PR DESCRIPTION
This commits solves the problem in communication between Master Node and Slave Nodes. 
Before, we could not see slave nodes (workers/executors) in the Hadoop UI (hadoop-master:8088), with this commit, we could do it by havingthe following changes:

1. Add `yarn-default.xml` to avoid error of minimum allocation requirements. 
This error is raised as follow: ResourceManager at master node looks at NodeManager at slaves, if RM finds some mismatch with the default configuration in Yarn (`min_mem_allocation`, `max_mem`, `min_vCore`, `max_vCore`,...), it will force the NM to stop. So, when you check by `jps` after a very short time, you couldn't see `NodeManager `at slaves anymore.  Adding `yarn-default.xml `with user-defined value will solve this issue. 
2. The `hosts `file is well configured for multinode cluster (localhost, master and slaves).
3. `Hadoop-master` is added to the `slaves `file, due to the fact that you could use Master node as a Datanode. 
4. File template `yarn-site.xml` is updated. 
5. Some tips to clean up `namenode `when restarting Hadoop service is added. 
6. Added `HADOOP_CONF_DIR `and `YARN_CONF_DIR` in the bashrc